### PR TITLE
Feature: notion idの登録・レスポンス・リンクを実装

### DIFF
--- a/backend/app/controllers/careers_controller.rb
+++ b/backend/app/controllers/careers_controller.rb
@@ -6,8 +6,8 @@ class CareersController < ApplicationController
   end
 
   def create
-    career.assign_attributes(career_params)
-    if career.save
+    career_notion.assign_attributes(career_params)
+    if career_notion.save
       flash[:success] = "Record successfully created"
       redirect_to careers_path
     else
@@ -23,8 +23,8 @@ class CareersController < ApplicationController
   end
 
   def update
-    career.assign_attributes(career_params)
-    if career.save
+    career_notion.assign_attributes(career_params)
+    if career_notion.save
       flash[:success] = "Record successfully updated"
       redirect_to careers_path
     else
@@ -59,7 +59,12 @@ class CareersController < ApplicationController
   end
   helper_method :career
 
+  def career_notion
+    @career_notion ||= CareerNotionForm.new(career:)
+  end
+  helper_method :career_notion
+
   def career_params
-    params.require(:career).permit(:title, :started_at, :ended_at, :description)
+    params.require(:career).permit(:title, :started_at, :ended_at, :description, :notion_key)
   end
 end

--- a/backend/app/forms/career_notion_form.rb
+++ b/backend/app/forms/career_notion_form.rb
@@ -1,0 +1,57 @@
+class CareerNotionForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :title, :string
+  attribute :started_at, :date
+  attribute :ended_at, :date
+  attribute :description, :string
+  attribute :notion_key, :string
+
+  validates :title, presence: true
+  validates :description, presence: true, length: { maximum: 500 }
+  validates :started_at, presence: true
+  validates :notion_key, presence: true
+
+  def initialize(career: Career.new, attributes: nil)
+    @career = career
+    attributes ||= default_attributes
+    super(attributes)
+  end
+
+  def save
+    return false if invalid?
+
+    ActiveRecord::Base.transaction do
+      career.assign_attributes(title:, started_at:, ended_at:, description:)
+      career.save!
+      notion = career.notion.presence || career.build_notion
+      notion.assign_attributes(key: notion_key)
+      notion.save!
+    end
+    true
+  rescue
+    false
+  end
+
+  def to_model
+    career
+  end
+
+  def persisted?
+    career.persisted?
+  end
+
+  private
+  attr_reader :career
+
+  def default_attributes
+    {
+      title: career.title,
+      started_at: career.started_at,
+      ended_at: career.ended_at,
+      description: career.description,
+      notion_key: career.notion&.key
+    }
+  end
+end

--- a/backend/app/forms/career_notion_form.rb
+++ b/backend/app/forms/career_notion_form.rb
@@ -51,7 +51,7 @@ class CareerNotionForm
       started_at: career.started_at,
       ended_at: career.ended_at,
       description: career.description,
-      notion_key: career.notion&.key
+      notion_key: career.notion_key
     }
   end
 end

--- a/backend/app/models/career.rb
+++ b/backend/app/models/career.rb
@@ -1,4 +1,6 @@
 class Career < ApplicationRecord
+  has_one :notion, as: :notionable, dependent: :destroy
+
   validates :title, presence: true
   validates :description, presence: true, length: { maximum: 500 }
   validates :started_at, presence: true

--- a/backend/app/models/career.rb
+++ b/backend/app/models/career.rb
@@ -4,4 +4,6 @@ class Career < ApplicationRecord
   validates :title, presence: true
   validates :description, presence: true, length: { maximum: 500 }
   validates :started_at, presence: true
+
+  delegate :key, to: :notion, prefix: true, allow_nil: true
 end

--- a/backend/app/models/notion.rb
+++ b/backend/app/models/notion.rb
@@ -1,0 +1,5 @@
+class Notion < ApplicationRecord
+  belongs_to :notionable, polymorphic: true
+
+  validates :key, presence: true
+end

--- a/backend/app/serializers/career_serializer.rb
+++ b/backend/app/serializers/career_serializer.rb
@@ -3,4 +3,5 @@ class CareerSerializer < ApplicationSerializer
   attribute :description
   attribute :started_at, key: :startedAt
   attribute :ended_at, key: :endedAt
+  attribute :notion_key, key: :notionKey
 end

--- a/backend/app/views/careers/_career_form.html.erb
+++ b/backend/app/views/careers/_career_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: career, class: "row g-3", data: {turbo: false} do |f| %>
+<%= form_with model: career_notion, class: "row g-3", data: {turbo: false} do |f| %>
   <div class="col-md-6">
     <%= f.label :title, "Title", class: "form-label" %>
     <%= f.text_field :title, class: "form-control" %>
@@ -10,6 +10,10 @@
   <div class="col-md-3">
     <%= f.label :ended_at, "Ended at", class: "form-label" %>
     <%= f.date_field :ended_at, class: "form-control" %>
+  </div>
+  <div class="col-md-3">
+    <%= f.label :notion_key, "Notion key", class: "form-label" %>
+    <%= f.text_field :notion_key, class: "form-control" %>
   </div>
   <div class="col-12">
     <%= f.label :description, "Description", class: "form-label" %>

--- a/backend/app/views/careers/show.html.erb
+++ b/backend/app/views/careers/show.html.erb
@@ -17,7 +17,7 @@
     </div>
     <div class="col-md-3">
       <small>Notoin key</small>
-      <div class="fs-4"><%= career.notion&.key %></div>
+      <div class="fs-4"><%= career.notion_key %></div>
     </div>
     <div class="col-12">
       <small>Description</small>

--- a/backend/app/views/careers/show.html.erb
+++ b/backend/app/views/careers/show.html.erb
@@ -15,6 +15,10 @@
       <small>Ended at</small>
       <div class="fs-4"><%= career.ended_at %></div>
     </div>
+    <div class="col-md-3">
+      <small>Notoin key</small>
+      <div class="fs-4"><%= career.notion&.key %></div>
+    </div>
     <div class="col-12">
       <small>Description</small>
       <div class="fs-5"><%= career.description %></div>

--- a/backend/db/migrate/20240629073011_create_notions.rb
+++ b/backend/db/migrate/20240629073011_create_notions.rb
@@ -1,0 +1,10 @@
+class CreateNotions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :notions do |t|
+      t.string :key
+      t.references :notionable, polymorphic: true
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_16_040143) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_29_073011) do
   create_table "careers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.string "title", default: "", null: false
@@ -20,6 +20,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_16_040143) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_careers_on_user_id"
+  end
+
+  create_table "notions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "key"
+    t.string "notionable_type"
+    t.bigint "notionable_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["notionable_type", "notionable_id"], name: "index_notions_on_notionable"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/backend/test/fixtures/notions.yml
+++ b/backend/test/fixtures/notions.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/backend/test/models/notion_test.rb
+++ b/backend/test/models/notion_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class NotionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/frontend/src/features/careers/components/career-item.module.scss
+++ b/frontend/src/features/careers/components/career-item.module.scss
@@ -44,4 +44,10 @@
       font-size: $fontsize-sm;
     }
   }
+  .content:hover {
+    .title {
+      text-decoration: underline;
+      text-decoration-thickness: 2px;
+    }
+  }
 }

--- a/frontend/src/features/careers/components/career-item.tsx
+++ b/frontend/src/features/careers/components/career-item.tsx
@@ -1,20 +1,23 @@
 import styles from "@/features/careers/components/career-item.module.scss";
 import { CareerItemProps } from "@/features/careers/types";
+import Link from "next/link";
 
 export default function CareerItem(props: CareerItemProps) {
   const { career } = props;
   return (
     <div className={styles.item} key={career.id}>
       <div className={styles.icon}></div>
-      <div className={styles.content}>
-        <div className={styles.head}>
-          <div className={styles.title}>{career.title}</div>
-          <div className={styles.period}>
-            {career.startedAt} ~ {career.endedAt}
+      <Link href={`/contents/${career.notionKey}`}>
+        <div className={styles.content}>
+          <div className={styles.head}>
+            <div className={styles.title}>{career.title}</div>
+            <div className={styles.period}>
+              {career.startedAt} ~ {career.endedAt}
+            </div>
           </div>
+          <div className={styles.description}>{career.description}</div>
         </div>
-        <div className={styles.description}>{career.description}</div>
-      </div>
+      </Link>
     </div>
   );
 }

--- a/frontend/src/infrastructure/repositories/career-repository.ts
+++ b/frontend/src/infrastructure/repositories/career-repository.ts
@@ -20,7 +20,8 @@ class CareerRepository {
       data.title,
       data.description,
       data.startedAt,
-      data.endedAt
+      data.endedAt,
+      data.notionKey
     );
   }
 }

--- a/frontend/src/models/career.ts
+++ b/frontend/src/models/career.ts
@@ -6,7 +6,8 @@ export default class Career {
     private _title: string,
     private _description: string,
     private _startedAt: string,
-    private _endedAt?: string
+    private _endedAt?: string,
+    private _notionKey?: string
   ) {}
 
   get id() {
@@ -27,6 +28,10 @@ export default class Career {
 
   get endedAt() {
     return this.formatDate(this._endedAt);
+  }
+
+  get notionKey() {
+    return this._notionKey;
   }
 
   private formatDate(date?: string) {


### PR DESCRIPTION
### 実装内容
notionテーブルを作成
careerとnotionのポリモーフィック関連を実装
careerとnotionのformオブジェクトを使った同時作成・同時更新機能
apiでnotionのkeyをcareerと一緒に返す
frontendにてcareerの一覧からnotion詳細ページへ遷移

### 動作確認方法
locahost:8080にて、careerの要素をクリックしてcareerの詳細ページが表示できることを確認